### PR TITLE
fix: allow remove base on urn uids

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -165,7 +165,10 @@ api.removeBase = (base, iri) => {
   // establish base root
   let root = '';
   if(base.href !== '') {
-    root += (base.protocol || '') + '//' + (base.authority || '');
+    root += base.protocol || '';
+    if(base.authority !== null) {
+      root += '//' + base.authority;
+    }
   } else if(iri.indexOf('//')) {
     // support network-path reference with empty base
     root += '//';


### PR DESCRIPTION
Create root in the same way prependBase creates a URL