### PR TITLE
fix: consider last path fragment as a directory

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -106,7 +106,6 @@ api.prependBase = (base, iri) => {
         let path = base.path;
 
         // append relative path to the end of the last directory from base
-        path = path.substr(0, path.lastIndexOf('/') + 1);
         if((path.length > 0 || base.authority) && path.substr(-1) !== '/') {
           path += '/';
         }


### PR DESCRIPTION
consider last fragment of path to be a directory, not a file.